### PR TITLE
Added badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ You may obtain a copy of the License at
 Karavi PowerFlex Metrics is part of the Karavi open source suite of Kubernetes storage enablers for Dell EMC products.
 
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md) 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
-[![Releases](https://img.shields.io/badge/Releases-green.svg)](https://github.com/dell/karavi-observability/releases)
+[![License](https://img.shields.io/github/license/dell/karavi-powerflex-metrics)](LICENSE)
+[![Docker Pulls](https://img.shields.io/docker/pulls/dellemc/karavi-powerflex-metrics)](https://hub.docker.com/r/dellemc/karavi-powerflex-metrics)
+[![Go version](https://img.shields.io/github/go-mod/go-version/dell/karavi-powerflex-metrics)](go.mod)
+[![Latest Release](https://img.shields.io/github/v/release/dell/karavi-powerflex-metrics?label=latest&style=flat-square)](https://github.com/dell/karavi-powerflex-metrics/releases)
 
 Karavi PowerFlex Metrics is an open source distributed solution that provides standardized approaches to gaining observability into Dell EMC products. Karavi PowerFlex Metrics provides the following metrics:
 - **[I/O Performance Metrics](./docs/IO_PERFORMANCE.md)**: Visibility into the I/O performance of a storage system (IOPS, bandwidth, latency) broken down by export node and volume 


### PR DESCRIPTION
# Description
Updated and added the following badges to the README:
- License badge will read from the LICENSE file in the repository
- Number of Docker image pulls from DockerHub
- Version of Go as found in the go.mod file
- Latest release

These badges will display errors until the GitHub and DockerHub repositories are set as public.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|   #1 Implement standards for OSS project      |

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have run 'make check' to ensure my code does not have any formatting, vetting, linting, or security issues
- [ ] I have run 'make test' to ensure new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degrade
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Make check output
Copy and paste the results output from running 'make check':

```# make check
./scripts/check.sh ./cmd/... ./opentelemetry/... ./internal/...
=== Checking format...
=== Finished
=== Vetting...
=== Finished
=== Linting...
=== Finished
=== Running gosec...
=== Finished
```

# Make test output
Copy and paste the results output from running 'make test':

```# make test
go test -count=1 -cover -race -timeout 30s -short ./...
?       github.com/dell/karavi-powerflex-metrics/cmd/powerflex-metrics  [no test files]
ok      github.com/dell/karavi-powerflex-metrics/internal/entrypoint    2.687s  coverage: 98.9% of statements
ok      github.com/dell/karavi-powerflex-metrics/internal/k8s   0.072s  coverage: 94.8% of statements
?       github.com/dell/karavi-powerflex-metrics/internal/k8s/mocks     [no test files]
ok      github.com/dell/karavi-powerflex-metrics/internal/service       0.680s  coverage: 94.5% of statements
?       github.com/dell/karavi-powerflex-metrics/internal/service/mocks [no test files]
?       github.com/dell/karavi-powerflex-metrics/opentelemetry/exporters        [no test files]
?       github.com/dell/karavi-powerflex-metrics/opentelemetry/exporters/mocks  [no test files]
```