### PR TITLE
Update workflow checks to include unit tests and code coverage verification

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,3 +25,13 @@ jobs:
         uses: dell/common-github-actions/code-sanitizer@main
         with:
           args: .
+  test:
+    name: Run Go unit tests and check package coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+      - name: Run unit tests and check package coverage
+        uses: dell/common-github-actions/go-code-tester@main
+        with:
+          threshold: 90


### PR DESCRIPTION
# Description
This PR adds a GitHub check in the workflow to run the dell/common-github-actions/go-code-tester on PRs. This check runs unit tests and verifies that each package has a code coverage level equal to or greater than a specified threshold.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|     [#8](https://github.com/dell/karavi-powerflex-metrics/issues/8) Update workflow to run unit tests and verify code coverage    |

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run 'make check' to ensure my code does not have any formatting, vetting, linting, or security issues
- [x] I have run 'make test' to ensure new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degrade
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

This has been tested by configuring this workflow in a test public repository and modifying pull requests to ensure that the check was passing and failing as expected for failed unit tests and code coverage threshold failures.

# Make check output
Copy and paste the results output from running 'make check':

```
./scripts/check.sh ./cmd/... ./opentelemetry/... ./internal/...
=== Checking format...
=== Finished
=== Vetting...
=== Finished
=== Linting...
=== Finished
=== Running gosec...
=== Finished
```

# Make test output
Copy and paste the results output from running 'make test':

```
go test -count=1 -cover -race -timeout 30s -short ./...
?       github.com/dell/karavi-powerflex-metrics/cmd/powerflex-metrics  [no test files]
ok      github.com/dell/karavi-powerflex-metrics/internal/entrypoint    2.707s  coverage: 98.9% of statements
ok      github.com/dell/karavi-powerflex-metrics/internal/k8s   0.085s  coverage: 94.8% of statements
?       github.com/dell/karavi-powerflex-metrics/internal/k8s/mocks     [no test files]
ok      github.com/dell/karavi-powerflex-metrics/internal/service       0.710s  coverage: 94.5% of statements
?       github.com/dell/karavi-powerflex-metrics/internal/service/mocks [no test files]
?       github.com/dell/karavi-powerflex-metrics/opentelemetry/exporters        [no test files]
?       github.com/dell/karavi-powerflex-metrics/opentelemetry/exporters/mocks  [no test files]
```