### PR TITLE
Remove clone of goscaleio dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,3 @@
-GOSCALEIO_DIR=../goscaleio
-GOSCALEIO_BRANCH=ioad-with-fixes
-GOSCALEIO_CLONED_BRANCH := $(shell git --git-dir=$(GOSCALEIO_DIR)/.git --work-tree=$(GOSCALEIO_DIR) rev-parse --abbrev-ref HEAD)
-
 .PHONY: all
 all: help
 
@@ -19,12 +15,6 @@ help:
 
 .PHONY: build
 build: generate
-	@if [ ! -d $(GOSCALEIO_DIR) ];then \
-		git clone --branch $(GOSCALEIO_BRANCH) https://github.com/dell/goscaleio.git $(GOSCALEIO_DIR); \
-	elif [ "$(GOSCALEIO_CLONED_BRANCH)" != "$(GOSCALEIO_BRANCH)" ];then \
-		git --git-dir=$(GOSCALEIO_DIR)/.git --work-tree=$(GOSCALEIO_DIR) fetch origin; \
-		git --git-dir=$(GOSCALEIO_DIR)/.git --work-tree=$(GOSCALEIO_DIR) checkout $(GOSCALEIO_BRANCH); \
-	fi
 	@$(foreach svc,$(shell ls cmd), CGO_ENABLED=0 GOOS=linux go build -o ./cmd/${svc}/bin/service ./cmd/${svc}/;)
 
 .PHONY: clean

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/dell/karavi-powerflex-metrics
 
 go 1.14
 
-replace github.com/dell/goscaleio => ../goscaleio
-
 require (
 	github.com/dell/goscaleio v1.2.0
 	github.com/golang/mock v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dell/goscaleio v1.2.0 h1:97x2rM0cRlBhy3povQe1OhxF4uI9vCgjRb/o19nP2d0=
+github.com/dell/goscaleio v1.2.0/go.mod h1:xrLhA17HgAXG616N7jQOatzVuxeZ5rfYsGSUBaQ7U8I=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=


### PR DESCRIPTION
# Description
This removes the dependency of a local clone of goscaleio. We can depend on goscaleio as a normal dependency.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|     #14      |

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run 'make check' to ensure my code does not have any formatting, vetting, linting, or security issues
- [x] I have run 'make test' to ensure new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degrade
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran a full build and all tests were successful

# Make check output
Copy and paste the results output from running 'make check':

```./scripts/check.sh ./cmd/... ./opentelemetry/... ./internal/...
=== Checking format...
=== Finished
=== Vetting...
=== Finished
=== Linting...
=== Finished
=== Running gosec...
=== Finished
```

# Make test output
Copy and paste the results output from running 'make test':

```go test -count=1 -cover -race -timeout 30s -short ./...
?       github.com/dell/karavi-powerflex-metrics/cmd/powerflex-metrics  [no test files]
ok      github.com/dell/karavi-powerflex-metrics/internal/entrypoint    2.697s  coverage: 98.9% of statements
ok      github.com/dell/karavi-powerflex-metrics/internal/k8s   0.065s  coverage: 94.8% of statements
?       github.com/dell/karavi-powerflex-metrics/internal/k8s/mocks     [no test files]
ok      github.com/dell/karavi-powerflex-metrics/internal/service       0.690s  coverage: 94.5% of statements
?       github.com/dell/karavi-powerflex-metrics/internal/service/mocks [no test files]
?       github.com/dell/karavi-powerflex-metrics/opentelemetry/exporters        [no test files]
?       github.com/dell/karavi-powerflex-metrics/opentelemetry/exporters/mocks  [no test files]
```