### PR TITLE
Update documentation to specify all 3rd party services must run in the same cluster as Karavi services

### DIFF
--- a/docs/GETTING_STARTED_GUIDE.md
+++ b/docs/GETTING_STARTED_GUIDE.md
@@ -36,7 +36,7 @@ Karavi PowerFlex Metrics current has support for the following Dell EMC storage 
 
 ### OpenTelemetry Collector
 
-[OpenTelemetry](https://blog.newrelic.com/product-news/what-is-opentelemetry/) standardizes how telemetry data can be collected and transferred to various open source observability tools. Karavi PowerFlex Metrics captures telemetry data and pushes it to the Open Telemetry Collector so it can be processed, and exported in an open-source telemetry data format of your choice. Simply point the observability tool of your choice, such as Prometheus, to scrape data from the Open Telemetry collector exporter endpoint.
+[OpenTelemetry](https://blog.newrelic.com/product-news/what-is-opentelemetry/) standardizes how telemetry data can be collected and transferred to various open source observability tools. Karavi PowerFlex Metrics captures telemetry data and pushes it to the Open Telemetry Collector so it can be processed, and exported in an open-source telemetry data format of your choice. Simply point the observability tool of your choice, such as Prometheus, to scrape data from the Open Telemetry collector exporter endpoint. The OpenTelemetry service should be running on the same Kubernetes cluster as the karavi-powerflex-metrics service.
 
 | Supported Version | Image                              | Helm Chart |
 | ----------------- | ---------------------------------- | ---------- |
@@ -46,7 +46,7 @@ The OpenTelemetry Collector must be configured with an exporter that is accessib
 
 ### Prometheus
 
-The [Grafana metrics dashboards](../grafana/dashboards/powerflex) require Prometheus to scrape the metrics data from the Open Telemetry Collector.
+The [Grafana metrics dashboards](../grafana/dashboards/powerflex) require Prometheus to scrape the metrics data from the Open Telemetry Collector. The Prometheus service should be running on the same Kubernetes cluster as the karavi-powerflex-metrics service.
 
 | Supported Version | Image                   | Helm Chart                                                   |
 | ----------------- | ----------------------- | ------------------------------------------------------------ |
@@ -58,7 +58,7 @@ If you have the Prometheus OpenTelemetry collector exporter configured, you must
 
 #### Grafana
 
-The [Grafana metrics dashboards](../grafana/dashboards/powerflex) require the following Grafana to be deployed in the k8s cluster. You must also have Prometheus and the OpenTelemetry Collector deployed (see above).
+The [Grafana metrics dashboards](../grafana/dashboards/powerflex) require the following Grafana to be deployed in the same Kubernetes cluster as the karavi-powerflex-metrics service. You must also have Prometheus and the OpenTelemetry Collector deployed (see above).
 
 | Supported Version | Image                 | Helm Chart                                                |
 | ----------------- | --------------------- | --------------------------------------------------------- |


### PR DESCRIPTION
# Description
This PR updated the Getting Started document to specify that all 3rd party services (OTEL collector, Prometheus, and Grafana) must run in the same cluster as Karavi powerflex metrics service.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|[#36](https://github.com/dell/karavi-powerflex-metrics/issues/36)|

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have run 'make check' to ensure my code does not have any formatting, vetting, linting, or security issues
- [ ] I have run 'make test' to ensure new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degrade
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Make check output
Copy and paste the results output from running 'make check':
N/A

# Make test output
N/A