### PR TITLE
Various fixes for links in docs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -23,6 +23,7 @@ Become one of the contributors to this project! We thrive to build a welcoming a
 * [Branching Strategy](#Branching-strategy)
 * [Signing your commits](#Signing-your-commits)
 * [Pull requests](#Pull-requests)
+* [Quality Gates for pull request](#Quality-Gates-for-pull-request)
 * [Code reviews](#Code-reviews)
 * [Code Style](#Code-Style)
 * [TODOs in the code](#TODOs-in-the-code)
@@ -80,7 +81,7 @@ Read more about the ways you can [Triage issues](ISSUE_TRIAGE.md).
 
 ## Your first contribution
 
-Unsure where to begin contributing to Karavi PowerFlex Metrics? Start by browsing issues labeled `beginner friendly` or `help wanted`.
+Unsure where to begin contributing to Karavi PowerFlex? Start by browsing issues labeled `beginner friendly` or `help wanted`.
 
 * [Beginner-friendly](https://github.com/dell/karavi-powerflex-metrics/issues?q=is%3Aopen+is%3Aissue+label%3A%22beginner+friendly%22) issues are generally straightforward to complete.
 * [Help wanted](https://github.com/dell/karavi-powerflex-metrics/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) issues are problems we would like the community to help us with regardless of complexity.

--- a/docs/ISSUE_TRIAGE.md
+++ b/docs/ISSUE_TRIAGE.md
@@ -31,7 +31,7 @@ The easiest way to find issues that haven't been triaged is to search for issues
 
 ## 2. Ensure the issue contains basic information
 
-Make sure that the issue's author provided the standard issue information. The Karavi PowerFlex Metrics project utilizes [GitHub issue templates](https://help.github.com/en/articles/creating-issue-templates-for-your-repository) to guide contributors to provide standard information that must be included for each type of template or type of issue.
+Make sure that the issue's author provided the standard issue information. The Karavi PowerFlex Metrics project utilizes GitHub issue templates to guide contributors to provide standard information that must be included for each type of template or type of issue.
 
 ### Standard issue information that must be included
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -14,7 +14,7 @@ This repository is inspected for security vulnerabilities via [gosec](https://gi
 
 Every issue detected by `gosec` is mapped to a [CWE (Common Weakness Enumeration)](http://cwe.mitre.org/data/index.html) which describes in more generic terms the vulnerability. The exact mapping can be found [here](https://github.com/securego/gosec/blob/master/issue.go#L49). The list of rules checked by `gosec` can be found [here](https://github.com/securego/gosec#available-rules).
 
-In addition to this, there are various security checks that get executed against a branch when a pull request is created/updated.  Please refer to [pull request](./CONTRIBUTING.md#pull-requests) for more information.
+In addition to this, there are various security checks that get executed against a branch when a pull request is created/updated.  Please refer to [pull request](/docs/CONTRIBUTING.md#pull-requests) for more information.
 
 ## Reporting a Vulnerability
 

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -10,7 +10,7 @@ You may obtain a copy of the License at
 
 # Support
 
-> Karavi PowerFlex Metrics has a [code of conduct](./docs/CODE_OF_CONDUCT.md).
+> Karavi PowerFlex Metrics has a [code of conduct](./CODE_OF_CONDUCT.md).
 > By interacting with this repository, organization, or community you agree to
 > abide by its terms.
 


### PR DESCRIPTION
# Description
Fixed typos and linting issues in markdown files.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|   #49        |

# Checklist:

- [x] I have performed a self-review of the documentation