### PR TITLE
Updates to suppress Kubernetes v1beta1 warnings 

### DIFF
--- a/internal/entrypoint/run_test.go
+++ b/internal/entrypoint/run_test.go
@@ -21,11 +21,11 @@ import (
 	metrics "github.com/dell/karavi-metrics-powerflex/internal/service/mocks"
 	otlexporters "github.com/dell/karavi-metrics-powerflex/opentelemetry/exporters"
 	exportermocks "github.com/dell/karavi-metrics-powerflex/opentelemetry/exporters/mocks"
-	"k8s.io/api/storage/v1beta1"
 
 	sio "github.com/dell/goscaleio"
 	"github.com/golang/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -623,7 +623,7 @@ func Test_Run(t *testing.T) {
 			pfClient := metrics.NewMockPowerFlexClient(ctrl)
 			pfClient.EXPECT().Authenticate(gomock.Any()).AnyTimes().Return(sio.Cluster{}, nil)
 
-			sc1 := v1beta1.StorageClass{}
+			sc1 := v1.StorageClass{}
 			sc1.Provisioner = "csi-vxflexos.dellemc.com"
 			sc1.ObjectMeta = metav1.ObjectMeta{
 				UID:  "123",
@@ -635,7 +635,7 @@ func Test_Run(t *testing.T) {
 
 			storageClassFinder := mocks.NewMockStorageClassFinder(ctrl)
 			storageClassFinder.EXPECT().GetStorageClasses().AnyTimes().
-				Return([]v1beta1.StorageClass{sc1}, nil)
+				Return([]v1.StorageClass{sc1}, nil)
 
 			leaderElector := mocks.NewMockLeaderElector(ctrl)
 			leaderElector.EXPECT().InitLeaderElection("karavi-metrics-powerflex", "karavi").Times(1).Return(nil)
@@ -736,7 +736,7 @@ func Test_Run(t *testing.T) {
 			pfClient := metrics.NewMockPowerFlexClient(ctrl)
 			pfClient.EXPECT().Authenticate(gomock.Any()).AnyTimes().Return(sio.Cluster{}, nil)
 
-			sc1 := v1beta1.StorageClass{}
+			sc1 := v1.StorageClass{}
 			sc1.Provisioner = "csi-vxflexos.dellemc.com"
 			sc1.ObjectMeta = metav1.ObjectMeta{
 				UID:  "123",
@@ -748,7 +748,7 @@ func Test_Run(t *testing.T) {
 
 			storageClassFinder := mocks.NewMockStorageClassFinder(ctrl)
 			storageClassFinder.EXPECT().GetStorageClasses().AnyTimes().
-				Return([]v1beta1.StorageClass{sc1}, nil)
+				Return([]v1.StorageClass{sc1}, nil)
 
 			leaderElector := mocks.NewMockLeaderElector(ctrl)
 			leaderElector.EXPECT().InitLeaderElection("karavi-metrics-powerflex", "karavi").Times(1).Return(nil)

--- a/internal/k8s/k8sapi.go
+++ b/internal/k8s/k8sapi.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/storage/v1beta1"
+	v1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/client-go/kubernetes"
@@ -36,7 +36,7 @@ func (api *API) GetCSINodes() (*v1.CSINodeList, error) {
 			return nil, err
 		}
 	}
-	return api.Client.StorageV1beta1().CSINodes().List(context.Background(), metav1.ListOptions{})
+	return api.Client.StorageV1().CSINodes().List(context.Background(), metav1.ListOptions{})
 }
 
 // GetPersistentVolumes will return a list of persistent volumes in the kubernetes cluster
@@ -62,7 +62,7 @@ func (api *API) GetStorageClasses() (*v1.StorageClassList, error) {
 			return nil, err
 		}
 	}
-	return api.Client.StorageV1beta1().StorageClasses().List(context.Background(), metav1.ListOptions{})
+	return api.Client.StorageV1().StorageClasses().List(context.Background(), metav1.ListOptions{})
 }
 
 // GetNodes will return the list of nodes in the kubernetes cluster

--- a/internal/k8s/k8sapi_test.go
+++ b/internal/k8s/k8sapi_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/storage/v1beta1"
+	v1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"

--- a/internal/k8s/mocks/kubernetes_api_mocks.go
+++ b/internal/k8s/mocks/kubernetes_api_mocks.go
@@ -6,7 +6,7 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "k8s.io/api/storage/v1beta1"
+	v1 "k8s.io/api/storage/v1"
 	reflect "reflect"
 )
 
@@ -34,10 +34,10 @@ func (m *MockKubernetesAPI) EXPECT() *MockKubernetesAPIMockRecorder {
 }
 
 // GetCSINodes mocks base method
-func (m *MockKubernetesAPI) GetCSINodes() (*v1beta1.CSINodeList, error) {
+func (m *MockKubernetesAPI) GetCSINodes() (*v1.CSINodeList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCSINodes")
-	ret0, _ := ret[0].(*v1beta1.CSINodeList)
+	ret0, _ := ret[0].(*v1.CSINodeList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/k8s/mocks/storage_class_getter_mocks.go
+++ b/internal/k8s/mocks/storage_class_getter_mocks.go
@@ -6,7 +6,7 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "k8s.io/api/storage/v1beta1"
+	v1 "k8s.io/api/storage/v1"
 	reflect "reflect"
 )
 
@@ -34,10 +34,10 @@ func (m *MockStorageClassGetter) EXPECT() *MockStorageClassGetterMockRecorder {
 }
 
 // GetStorageClasses mocks base method
-func (m *MockStorageClassGetter) GetStorageClasses() (*v1beta1.StorageClassList, error) {
+func (m *MockStorageClassGetter) GetStorageClasses() (*v1.StorageClassList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStorageClasses")
-	ret0, _ := ret[0].(*v1beta1.StorageClassList)
+	ret0, _ := ret[0].(*v1.StorageClassList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/k8s/sdc_finder.go
+++ b/internal/k8s/sdc_finder.go
@@ -11,7 +11,7 @@ package k8s
 import (
 	"strings"
 
-	v1 "k8s.io/api/storage/v1beta1"
+	v1 "k8s.io/api/storage/v1"
 )
 
 // KubernetesAPI is an interface for accessing the Kubernetes API

--- a/internal/k8s/sdc_finder_test.go
+++ b/internal/k8s/sdc_finder_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/dell/karavi-metrics-powerflex/internal/k8s"
 	"github.com/dell/karavi-metrics-powerflex/internal/k8s/mocks"
 
-	v1 "k8s.io/api/storage/v1beta1"
+	v1 "k8s.io/api/storage/v1"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"

--- a/internal/k8s/storageclass_finder.go
+++ b/internal/k8s/storageclass_finder.go
@@ -9,7 +9,7 @@
 package k8s
 
 import (
-	v1 "k8s.io/api/storage/v1beta1"
+	v1 "k8s.io/api/storage/v1"
 )
 
 // StorageClassGetter is an interface for getting a list of storage class information

--- a/internal/k8s/storageclass_finder_test.go
+++ b/internal/k8s/storageclass_finder_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/storage/v1beta1"
+	v1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/service/mocks/storage_class_finder_mocks.go
+++ b/internal/service/mocks/storage_class_finder_mocks.go
@@ -6,7 +6,7 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "k8s.io/api/storage/v1beta1"
+	v1 "k8s.io/api/storage/v1"
 	reflect "reflect"
 )
 
@@ -34,10 +34,10 @@ func (m *MockStorageClassFinder) EXPECT() *MockStorageClassFinderMockRecorder {
 }
 
 // GetStorageClasses mocks base method
-func (m *MockStorageClassFinder) GetStorageClasses() ([]v1beta1.StorageClass, error) {
+func (m *MockStorageClassFinder) GetStorageClasses() ([]v1.StorageClass, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStorageClasses")
-	ret0, _ := ret[0].([]v1beta1.StorageClass)
+	ret0, _ := ret[0].([]v1.StorageClass)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -20,7 +20,7 @@ import (
 	sio "github.com/dell/goscaleio"
 	types "github.com/dell/goscaleio/types/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/storage/v1beta1"
+	v1 "k8s.io/api/storage/v1"
 )
 
 var _ Service = (*PowerFlexService)(nil)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -27,7 +27,7 @@ import (
 	sio "github.com/dell/goscaleio"
 	types "github.com/dell/goscaleio/types/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/storage/v1beta1"
+	v1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 


### PR DESCRIPTION
# Description

This PR updates Kubernetes references to v1beta1 for StorageClass and CSINode to use v1 instead.  The reason is that warning messages are being displayed in the logs indicating support will be removed for k8s.io/api/storage/v1beta1 by k8s v1.22.  Making the change now because it's backward compatible with older versions of kubernetes.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|     https://github.com/dell/karavi-observability/issues/32     |

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run 'make check' to ensure my code does not have any formatting, vetting, linting, or security issues
- [x] I have run 'make test' to ensure new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degrade
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

- [x] Unit tests
- [x] Execute E2E tests against Kubernetes v1.18
- [x] Execute E2E tests against Kubernetes v1.19
- [x] Execute E2E tests against Kubernetes v1.20