### PR TITLE
Use value from storage system config to determine client parameters

### DIFF
--- a/cmd/metrics-powerflex/main.go
+++ b/cmd/metrics-powerflex/main.go
@@ -159,7 +159,7 @@ func updatePowerFlexConnection(config *entrypoint.Config, sdcFinder *k8s.SDCFind
 	storageClassFinder.IsDefaultStorageSystem = storageSystem.IsDefault
 	volumeFinder.StorageSystemID = powerFlexSystemID
 
-	client, err := sio.NewClientWithArgs(powerFlexEndpoint, "", true, false)
+	client, err := sio.NewClientWithArgs(powerFlexEndpoint, "", storageSystem.Insecure, true)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
# Description
The upcoming configuration changes for the CSI Driver for PowerFlex contains a value to determine if the connection should be secure or insecure. This change will set the proper flag on the goscaleio client for the given storage system. Also, the second flag is set to true to load any certificates. This aligns with the same client configuration used by the CSI driver.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|  https://github.com/dell/karavi-observability/issues/30        |

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run 'make check' to ensure my code does not have any formatting, vetting, linting, or security issues
- [x] I have run 'make test' to ensure new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degrade
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Deployed metrics-powerflex and verified metrics were able to be retrieved from the goscaleio client
- [x] Deployed metrics-powerflex in an environment with Karavi Authorization and verified metrics were able to be retrieved from the goscaleio client.
