### PR TITLE
Support yaml and skipCertificateValidation in secret parsing

### DIFF
--- a/cmd/metrics-powerflex/main.go
+++ b/cmd/metrics-powerflex/main.go
@@ -187,7 +187,9 @@ func updatePowerFlexConnection(config *entrypoint.Config, sdcFinder *k8s.SDCFind
 		storageClassFinder.StorageSystemID[i] = storageID
 		volumeFinder.StorageSystemID[i] = storageID
 
-		client, err := sio.NewClientWithArgs(powerFlexEndpoint, "", storageSystem.Insecure, true)
+		// backwards compatible with previous 'Insecure' flag
+		insecure := storageSystem.Insecure || storageSystem.SkipCertificateValidation
+		client, err := sio.NewClientWithArgs(powerFlexEndpoint, "", insecure, true)
 		if err != nil {
 			logger.WithError(err).Fatal("creating powerflex client")
 		}

--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,5 @@ require (
 	k8s.io/api v0.21.4
 	k8s.io/apimachinery v0.21.4
 	k8s.io/client-go v0.21.4
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/internal/entrypoint/run_test.go
+++ b/internal/entrypoint/run_test.go
@@ -845,7 +845,7 @@ func Test_Run(t *testing.T) {
 			entrypoint.ConfigValidatorFunc = noCheckConfig
 
 			e := exportermocks.NewMockOtlexporter(ctrl)
-			e.EXPECT().InitExporter(gomock.Any(), gomock.Any()).Return(nil)
+			e.EXPECT().InitExporter(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 			e.EXPECT().StopExporter().Return(nil)
 
 			svc := metrics.NewMockService(ctrl)

--- a/internal/service/configuration_reader.go
+++ b/internal/service/configuration_reader.go
@@ -9,21 +9,23 @@
 package service
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"sigs.k8s.io/yaml"
 )
 
 // ArrayConnectionData contains data required to connect to array
 type ArrayConnectionData struct {
-	SystemID  string `json:"systemID"`
-	Username  string `json:"username"`
-	Password  string `json:"password"`
-	Endpoint  string `json:"endpoint"`
-	Insecure  bool   `json:"insecure,omitempty"`
-	IsDefault bool   `json:"isDefault,omitempty"`
+	SystemID                  string `json:"systemID"`
+	Username                  string `json:"username"`
+	Password                  string `json:"password"`
+	Endpoint                  string `json:"endpoint"`
+	Insecure                  bool   `json:"insecure,omitempty"`
+	IsDefault                 bool   `json:"isDefault,omitempty"`
+	SkipCertificateValidation bool   `json:"skipCertificateValidation,omitempty"`
 }
 
 // ConfigurationReader handles reading of the storage system configuration secret
@@ -47,7 +49,13 @@ func (c *ConfigurationReader) GetStorageSystemConfiguration(file string) ([]Arra
 	}
 
 	connectionData := make([]ArrayConnectionData, 0)
-	err = json.Unmarshal(config, &connectionData)
+	// support backward compatibility
+	config, err = yaml.JSONToYAML(config)
+	if err != nil {
+		return nil, fmt.Errorf(fmt.Sprintf("converting json to yaml: %v", err))
+	}
+
+	err = yaml.Unmarshal(config, &connectionData)
 	if err != nil {
 		return nil, fmt.Errorf(fmt.Sprintf("Unable to parse the credentials: %v", err))
 	}

--- a/internal/service/configuration_reader_test.go
+++ b/internal/service/configuration_reader_test.go
@@ -38,7 +38,7 @@ func Test_ConfigurationReader(t *testing.T) {
 	}
 
 	tests := map[string]func(t *testing.T) (service.ConfigurationReader, string, []checkFn){
-		"success with no default system in config": func(*testing.T) (service.ConfigurationReader, string, []checkFn) {
+		"success json with no default system in config": func(*testing.T) (service.ConfigurationReader, string, []checkFn) {
 			file := "testdata/config-with-no-default.json"
 			configReader := service.ConfigurationReader{}
 
@@ -57,6 +57,56 @@ func Test_ConfigurationReader(t *testing.T) {
 					SystemID: "ID2",
 					Endpoint: "https://127.0.0.2",
 					Insecure: true,
+				},
+			}
+
+			return configReader, file, check(hasNoError, checkExpectedOutput(expectedResult))
+		},
+		"success yaml with no default system in config": func(*testing.T) (service.ConfigurationReader, string, []checkFn) {
+			file := "testdata/config-with-no-default.yaml"
+			configReader := service.ConfigurationReader{}
+
+			expectedResult := []service.ArrayConnectionData{
+				{
+					Username:  "admin",
+					Password:  "password",
+					SystemID:  "ID1",
+					Endpoint:  "http://127.0.0.1",
+					Insecure:  true,
+					IsDefault: false,
+				},
+				{
+					Username: "admin",
+					Password: "password",
+					SystemID: "ID2",
+					Endpoint: "https://127.0.0.2",
+					Insecure: true,
+				},
+			}
+
+			return configReader, file, check(hasNoError, checkExpectedOutput(expectedResult))
+		},
+		"success yaml with skipCertificateValidation": func(*testing.T) (service.ConfigurationReader, string, []checkFn) {
+			file := "testdata/config-with-skipCertificateValidation.yaml"
+			configReader := service.ConfigurationReader{}
+
+			expectedResult := []service.ArrayConnectionData{
+				{
+					Username:                  "admin",
+					Password:                  "password",
+					SystemID:                  "ID1",
+					Endpoint:                  "http://127.0.0.1",
+					Insecure:                  false,
+					SkipCertificateValidation: true,
+					IsDefault:                 false,
+				},
+				{
+					Username:                  "admin",
+					Password:                  "password",
+					SystemID:                  "ID2",
+					Endpoint:                  "https://127.0.0.2",
+					Insecure:                  false,
+					SkipCertificateValidation: false,
 				},
 			}
 

--- a/internal/service/testdata/config-with-no-default.yaml
+++ b/internal/service/testdata/config-with-no-default.yaml
@@ -1,0 +1,13 @@
+---
+- username: admin
+  password: password
+  systemID: ID1
+  endpoint: http://127.0.0.1
+  insecure: true
+  mdm: mdm1,mdm2
+- username: admin
+  password: password
+  systemID: ID2
+  endpoint: https://127.0.0.2
+  insecure: true
+  mdm: mdm3,mdm4

--- a/internal/service/testdata/config-with-skipCertificateValidation.yaml
+++ b/internal/service/testdata/config-with-skipCertificateValidation.yaml
@@ -1,0 +1,13 @@
+---
+- username: admin
+  password: password
+  systemID: ID1
+  endpoint: http://127.0.0.1
+  skipCertificateValidation: true
+  mdm: mdm1,mdm2
+- username: admin
+  password: password
+  systemID: ID2
+  endpoint: https://127.0.0.2
+  skipCertificateValidation: false
+  mdm: mdm3,mdm4


### PR DESCRIPTION
# Description
Updated the secret parsing:
- Supports either yaml or json
- Added the new key for skipCertificateValidation

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/137 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] E2E tests passed `ok      karavi-testing/karavi-metrics/metrics-test      110.532s`
