### PR TITLE
Update GO to 1.20

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -58,10 +58,10 @@ jobs:
     name: Image Scanner
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19+
+      - name: Set up Go 1.20+
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.19
+          go-version: ^1.20
         id: go
       - name: Checkout the code
         uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dell/karavi-metrics-powerflex
 
-go 1.19
+go 1.20
 
 require (
 	github.com/dell/goscaleio v1.9.0


### PR DESCRIPTION
# Description
Update GO to 1.20

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/658|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have inspected the Grafana dashboards to verify the data is displayed properly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] make check test
```
./scripts/check.sh ./cmd/... ./opentelemetry/... ./internal/...
=== Checking format...
=== Finished
=== Vetting...
=== Finished
=== Linting...
=== Finished
=== Running gosec...
=== Finished
go test -count=1 -cover -race -timeout 30s -short ./...
?       github.com/dell/karavi-metrics-powerflex/cmd/metrics-powerflex  [no test files]
?       github.com/dell/karavi-metrics-powerflex/internal/k8s/mocks     [no test files]
?       github.com/dell/karavi-metrics-powerflex/internal/service/mocks [no test files]
?       github.com/dell/karavi-metrics-powerflex/opentelemetry/exporters       [no test files]
?       github.com/dell/karavi-metrics-powerflex/opentelemetry/exporters/mocks [no test files]
ok      github.com/dell/karavi-metrics-powerflex/internal/entrypoint    2.906s coverage: 90.2% of statements
ok      github.com/dell/karavi-metrics-powerflex/internal/k8s   0.102s  coverage: 91.9% of statements
ok      github.com/dell/karavi-metrics-powerflex/internal/service       1.051s coverage: 94.1% of statements
```

# Manual inspection of the GUI
I have verified that the dashboards show the data properly while generating I/O and storage resources

- [] Yes
- [x] No
