### PR TITLE
Update goscaleio to v1.10.0

### DIFF
--- a/cmd/metrics-powerflex/main.go
+++ b/cmd/metrics-powerflex/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -197,7 +198,7 @@ func updatePowerFlexConnection(config *entrypoint.Config, sdcFinder *k8s.SDCFind
 
 		// backwards compatible with previous 'Insecure' flag
 		insecure := storageSystem.Insecure || storageSystem.SkipCertificateValidation
-		client, err := sio.NewClientWithArgs(powerFlexEndpoint, "", insecure, true)
+		client, err := sio.NewClientWithArgs(powerFlexEndpoint, "", math.MaxInt64, insecure, true)
 		if err != nil {
 			logger.WithError(err).Fatal("creating powerflex client")
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dell/karavi-metrics-powerflex
 go 1.20
 
 require (
-	github.com/dell/goscaleio v1.9.0
+	github.com/dell/goscaleio v1.10.0
 	github.com/fsnotify/fsnotify v1.5.3
 	github.com/golang/mock v1.6.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dell/goscaleio v1.9.0 h1:7A43HVUIYdIt0o0r3wlDVeZDOUlrVEjX+A+IAseGsSs=
-github.com/dell/goscaleio v1.9.0/go.mod h1:f+OsYKdKJc8j/a0uHI6nJZpiMfx7wDd6yq78dAeBHsg=
+github.com/dell/goscaleio v1.10.0 h1:XCEI9j+IlbqNPY7uvBjNNlT0Nt2PMXlnyxUavmennVY=
+github.com/dell/goscaleio v1.10.0/go.mod h1:Zh2iQ44Jd8FMqU2h+rT5x1K6mdPMKQ15lkFxojU4z3w=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=


### PR DESCRIPTION
# Description
Update goscaleio to v1.10.0

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/583|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have inspected the Grafana dashboards to verify the data is displayed properly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] make check test
```
❯ make check test
./scripts/check.sh ./cmd/... ./opentelemetry/... ./internal/...
=== Checking format...
=== Finished
=== Vetting...
=== Finished
=== Linting...
=== Finished
=== Running gosec...
=== Finished
go test -count=1 -cover -race -timeout 30s -short ./...
?       github.com/dell/karavi-metrics-powerflex/cmd/metrics-powerflex  [no test files]
?       github.com/dell/karavi-metrics-powerflex/internal/k8s/mocks     [no test files]
?       github.com/dell/karavi-metrics-powerflex/internal/service/mocks [no test files]
?       github.com/dell/karavi-metrics-powerflex/opentelemetry/exporters       [no test files]
?       github.com/dell/karavi-metrics-powerflex/opentelemetry/exporters/mocks [no test files]
ok      github.com/dell/karavi-metrics-powerflex/internal/entrypoint    2.922s coverage: 90.2% of statements
ok      github.com/dell/karavi-metrics-powerflex/internal/k8s   0.089s  coverage: 91.9% of statements
ok      github.com/dell/karavi-metrics-powerflex/internal/service       0.801s coverage: 94.1% of statements
```

# Manual inspection of the GUI
I have verified that the dashboards show the data properly while generating I/O and storage resources

- [ ] Yes
- [x] No
