### PR TITLE
Use common CSM properties during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:630cf7bdef807f048cadfe7180d6c27eb3aaa99323ffc3628811da230ed3322a
+ARG BASEIMAGE
+
+FROM $BASEIMAGE as final
 LABEL vendor="Dell Inc." \
       name="csm-metrics-powerflex" \
       summary="Dell Container Storage Modules (CSM) for Observability - Metrics for PowerFlex" \

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,7 @@ test:
 
 .PHONY: download-csm-common
 download-csm-common:
-	# TODO point to main branch
-	curl -O -L https://raw.githubusercontent.com/dell/csm/default-base-image/config/csm-common.mk
+	curl -O -L https://raw.githubusercontent.com/dell/csm/main/config/csm-common.mk
 
 .PHONY: docker
 docker: download-csm-common

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,15 @@ generate:
 test:
 	go test -count=1 -cover -race -timeout 30s -short ./...
 
+.PHONY: download-csm-common
+download-csm-common:
+	# TODO point to main branch
+	curl -O -L https://raw.githubusercontent.com/dell/csm/default-base-image/config/csm-common.mk
+
 .PHONY: docker
-docker:
-	SERVICE=cmd/metrics-powerflex docker build -t csm-metrics-powerflex -f Dockerfile cmd/metrics-powerflex/
+docker: download-csm-common
+	$(eval include csm-common.mk)
+	SERVICE=cmd/metrics-powerflex docker build -t csm-metrics-powerflex -f Dockerfile --build-arg BASEIMAGE=$(DEFAULT_BASEIMAGE) cmd/metrics-powerflex/
 
 .PHONY: push
 push:


### PR DESCRIPTION
# Description
Use common CSM properties during build.
- Makefile will download the csm-common.mk file which includes a parameter of DEFAULT_BASEIMAGE
- The DEFAULT_BASEIMAGE parameter will be sent as an argument to the build

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1031 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have inspected the Grafana dashboards to verify the data is displayed properly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Successfully built the image with the common base image

# Manual inspection of the GUI
I have verified that the dashboards show the data properly while generating I/O and storage resources

- [ ] Yes
- [ ] No
