### PR TITLE
go version bump-up

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -60,6 +60,9 @@ jobs:
     steps:
       - name: Set up Go lastest
         uses: actions/setup-go@v5
+        with:
+          go-version: ^1.22
+          cache: false
         id: go
       - name: Checkout the code
         uses: actions/checkout@v4

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -35,7 +35,6 @@ jobs:
         uses: dell/common-github-actions/go-code-tester@main
         with:
           threshold: 90
-          skip-list: "karavi-metrics-powerflex/internal/entrypoint,karavi-metrics-powerflex/internal/k8s,karavi-metrics-powerflex/internal/service"
   go_security_scan:
     name: Go security
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -35,6 +35,7 @@ jobs:
         uses: dell/common-github-actions/go-code-tester@main
         with:
           threshold: 90
+          skip-list: "karavi-metrics-powerflex/internal/entrypoint,karavi-metrics-powerflex/internal/k8s,karavi-metrics-powerflex/internal/service"
   go_security_scan:
     name: Go security
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dell/karavi-metrics-powerflex
 
-go 1.21
+go 1.22
 
 require (
 	github.com/dell/goscaleio v1.13.0


### PR DESCRIPTION
Updating go version to latest available i.e. => 1.22