### PR TITLE
Bugfix set log level

### DIFF
--- a/cmd/metrics-powerflex/main.go
+++ b/cmd/metrics-powerflex/main.go
@@ -56,7 +56,6 @@ func main() {
 
 func configure() (*entrypoint.Config, otlexporters.Otlexporter, *service.PowerFlexService) {
 	logger := setupLogger()
-	loadConfig(logger)
 	configFileListener := setupConfigFileListener()
 	sdcFinder, storageClassFinder, leaderElectorGetter, volumeFinder, nodeFinder, exporter := initializeComponents(logger)
 	config := setupConfig(sdcFinder, storageClassFinder, leaderElectorGetter, volumeFinder, nodeFinder, logger)
@@ -90,6 +89,7 @@ func initializeComponents(logger *logrus.Logger) (*k8s.SDCFinder, *k8s.StorageCl
 
 func setupLogger() *logrus.Logger {
 	logger := logrus.New()
+	loadConfig(logger)
 	updateLoggingSettings(logger)
 	return logger
 }
@@ -165,6 +165,8 @@ func onChangeUpdate(
 }
 
 func updateLoggingSettings(logger *logrus.Logger) {
+	fmt.Printf("Config cahange called in updateLoggingSettings")
+	logger.Info("SP:update logging settings")
 	logFormat := viper.GetString("LOG_FORMAT")
 	if strings.EqualFold(logFormat, "json") {
 		logger.SetFormatter(&logrus.JSONFormatter{})
@@ -185,6 +187,7 @@ func updateLoggingSettings(logger *logrus.Logger) {
 func setupConfigWatchers(configFileListener *viper.Viper, powerflexSvc *service.PowerFlexService, config *entrypoint.Config, sdcFinder *k8s.SDCFinder, storageClassFinder *k8s.StorageClassFinder, volumeFinder *k8s.VolumeFinder, exporter *otlexporters.OtlCollectorExporter, logger *logrus.Logger) {
 	viper.WatchConfig()
 	viper.OnConfigChange(func(_ fsnotify.Event) {
+		fmt.Printf("Config cahange called in setupConfigWatchers")
 		updateLoggingSettings(logger)
 	})
 

--- a/cmd/metrics-powerflex/main.go
+++ b/cmd/metrics-powerflex/main.go
@@ -165,8 +165,6 @@ func onChangeUpdate(
 }
 
 func updateLoggingSettings(logger *logrus.Logger) {
-	fmt.Printf("Config cahange called in updateLoggingSettings")
-	logger.Info("SP:update logging settings")
 	logFormat := viper.GetString("LOG_FORMAT")
 	if strings.EqualFold(logFormat, "json") {
 		logger.SetFormatter(&logrus.JSONFormatter{})


### PR DESCRIPTION
# Description
LOG_LEVEL was resetting to INFO if there was metrics pod restart

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have inspected the Grafana dashboards to verify the data is displayed properly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] e2e tests
<img width="825" height="257" alt="image" src="https://github.com/user-attachments/assets/28c29f59-0d01-4609-a23d-a5b221369f19" />

- [x] debug config doesnt get reset to info during metrics pod restart
<img width="1582" height="283" alt="image" src="https://github.com/user-attachments/assets/86680362-b06b-43e7-80b8-5a73ec3080af" />



